### PR TITLE
doap.xml: add schema:logo

### DIFF
--- a/doap.xml
+++ b/doap.xml
@@ -18,6 +18,8 @@
         <bug-database rdf:resource="https://github.com/dappros/ethora/issues"/>
         <support-forum rdf:resource="https://discord.gg/Sm6bAHA3ZC"/>
 
+        <schema:logo rdf:resource="https://raw.githubusercontent.com/dappros/ethora-mcp-server/main/assets/icon-400.png"/>
+
         <license rdf:resource="https://github.com/dappros/ethora/blob/main/LICENSE"/>
 
         <language>en</language>


### PR DESCRIPTION
Adds a `<schema:logo>` element to the project's DOAP file, suggested by guusdk on xsf/xmpp.org#1681. Helps xmpp.org and other DOAP consumers render the project with an icon.

Uses the existing Ethora icon (`icon-400.png` from the `ethora-mcp-server` repo). XML is well-formed (validated with `xml.etree`).